### PR TITLE
Add validator cleanup method

### DIFF
--- a/test-operations/src/main/java/com/vmware/operations/OperationAsyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationAsyncBase.java
@@ -102,9 +102,8 @@ public abstract class OperationAsyncBase extends OperationBase {
     public final void cleanup() {
         try {
             cleanupAsync().get();
-        } catch (Throwable throwable) {
+        } catch (Exception ex) {
             // Swallow the error
-            logger.info("Cleanup error {}", throwable.getMessage());
         }
     }
 
@@ -117,9 +116,19 @@ public abstract class OperationAsyncBase extends OperationBase {
             if (isExecuted()) {
                 return revertAsync();
             }
-        } catch (Exception ex) {
+        } catch (Throwable throwable) {
             // Catch all failures, and suppress them during cleanup
+            logger.info("Cleanup error {}", throwable.getMessage());
         }
+
+        // Tell the validators goodbye, in case revert failed.
+        try {
+            validateCleanup(executorService);
+        } catch (Throwable throwable) {
+            // Catch all failures, and suppress them during cleanup
+            logger.info("Cleanup validators error {}", throwable.getMessage());
+        }
+
         return CompletableFuture.completedFuture(null);
     }
 

--- a/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
@@ -119,8 +119,19 @@ public abstract class OperationSyncBase extends OperationBase {
     public void cleanup() {
         try {
             if (isExecuted()) {
-                revertImpl();
+                revert();
             }
+        } catch (Throwable throwable) {
+            // Catch failures, and suppress them during cleanup
+            handleCleanupException(throwable);
+        }
+
+        // If revert failed, then it could have been the operation or the
+        // validators that threw the error.  Ensure the validators
+        // are cleaned up before leaving.
+
+        try {
+            validateCleanup(executorService).get();
         } catch (Throwable throwable) {
             // Catch failures, and suppress them during cleanup
             handleCleanupException(throwable);

--- a/test-operations/src/main/java/com/vmware/operations/Validator.java
+++ b/test-operations/src/main/java/com/vmware/operations/Validator.java
@@ -26,32 +26,47 @@ import java.util.concurrent.ExecutorService;
  */
 public interface Validator {
     /**
-     * Return an operation which will validate an aspect of the request, or null if
-     * this validator is not applicable.
-     * <p>
-     * The provisioning operation will wait for the returned operation to complete, or
-     * pass along the exception if there was a failure.
+     * Perform an action to validate the execution of an operation.
+     *
+     * This is called after the execute operation has been completed.  The initiating
+     * operation will wait for the validator to complete, passing along the exception
+     * if there was a failure.
      *
      * @param executorService An executor for running validations on other threads
-     * @param initiatingOp The composition service provisioning request
-     * @return an operation that will validate an aspect of request or null if this
-     * validator is not applicable to the request.  The result of the future should
-     * be the number of components in the request which were validated.
+     * @param initiatingOp The operation that is being validated
+     * @return a future that completes when the validation is done or has an error.
      */
-    CompletableFuture<Void> validateExecutionAsync(ExecutorService executorService, Operation initiatingOp);
+    CompletableFuture<?> validateExecutionAsync(ExecutorService executorService, Operation initiatingOp);
 
     /**
-     * Return an operation which will validate an aspect of the destroy request, or null if
-     * this validator is not applicable.
-     * <p>
-     * The destroy operation will wait for the returned operation to complete, or
-     * pass along the exception if there was a failure.
+     * Perform an action to validate the revert of an operation.
+     *
+     * This is called after the revert operation has been completed.  The initiating
+     * operation will wait for the validator to complete, passing along the exception
+     * if there was a failure.
      *
      * @param executorService An executor for running validations on other threads
-     * @param initiatingOp The composition service provisioning request
-     * @return an operation that will validate an aspect of destroy request or null if this
-     * validator is not applicable to the request.   The result of the future should
-     * be the number of components in the request which were validated.
+     * @param initiatingOp The operation that is being validated
+     * @return a future that completes when the validation is done or has an error.
      */
-    CompletableFuture<Void> validateRevertAsync(ExecutorService executorService, Operation initiatingOp);
+    CompletableFuture<?> validateRevertAsync(ExecutorService executorService, Operation initiatingOp);
+
+    /**
+     * Perform an action to cleanup the validator in case the execution of
+     * an operation succeeded, but revert of the operation failed (in that case validateRevert()
+     * will not normally be called).
+     *
+     * Generally, nothing needs to be done, but for validators that keep state, they
+     * can use this method to clean up.
+     *
+     * Note that if the *validator* fails during revert, validateCleanupAsync will not be called.
+     *
+     * The initiating operation will wait for the validator to complete.  Exceptions
+     * during cleanup will be ignored.
+     *
+     * @param executorService An executor for running validations on other threads
+     * @param initiatingOp The operation that is being validated
+     * @return a future that completes when the cleanup is done or has an error.
+     */
+    CompletableFuture<?> validateCleanupAsync(ExecutorService executorService, Operation initiatingOp);
 }

--- a/test-operations/src/test/java/com/vmware/operations/IncrementSyncValidator.java
+++ b/test-operations/src/test/java/com/vmware/operations/IncrementSyncValidator.java
@@ -80,7 +80,18 @@ public class IncrementSyncValidator extends ValidatorSyncBase<Operation> {
             Thread.sleep(delayMillis);
         }
 
-        data.decrementAndGet();
+        data.addAndGet(1000);
+    }
+
+    @Override
+    public void validateCleanup(Operation op) throws Exception {
+        logger.info("Validating cleanup {}", toString());
+
+        if (delayMillis > 0) {
+            Thread.sleep(delayMillis);
+        }
+
+        data.addAndGet(1000000);
     }
 
     @Override

--- a/test-operations/src/test/java/com/vmware/operations/ValidatorFailureTest.java
+++ b/test-operations/src/test/java/com/vmware/operations/ValidatorFailureTest.java
@@ -102,16 +102,17 @@ public class ValidatorFailureTest extends OperationTestBase {
 
         // The revert command should execute without error.
         // The validator will also run, so we see the side-effect
-        // value getting decremented.
+        // value getting incremented.
         cmd.revert();
 
         Assert.assertFalse(cmd.isExecuted());
         Assert.assertEquals(0, opValue.get());
-        Assert.assertEquals(-1, validValue.get());
+        Assert.assertEquals(1000, validValue.get());
 
         cmd.close();
 
         Assert.assertEquals(0, opValue.get());
+        Assert.assertEquals(1000, validValue.get());
     }
 
     /**
@@ -182,11 +183,12 @@ public class ValidatorFailureTest extends OperationTestBase {
 
         Assert.assertFalse(cmd.isExecuted());
         Assert.assertEquals(0, opValue.get());
-        Assert.assertEquals(-1, validValue.get());
+        Assert.assertEquals(1000, validValue.get());
 
         cmd.close();
 
         Assert.assertEquals(0, opValue.get());
+        Assert.assertEquals(1000, validValue.get());
     }
 
     /**

--- a/test-operations/src/test/java/com/vmware/operations/ValidatorTests.java
+++ b/test-operations/src/test/java/com/vmware/operations/ValidatorTests.java
@@ -45,7 +45,7 @@ public class ValidatorTests {
 
         op.revert();
         Assert.assertEquals("operation count should match", 0, opCount.get());
-        Assert.assertEquals("validation count should match", 0, validationCount.get());
+        Assert.assertEquals("validation count should match", 1001, validationCount.get());
     }
 
     /**
@@ -65,7 +65,47 @@ public class ValidatorTests {
 
         op.revert();
         Assert.assertEquals("operation count should match", 0, opCount.get());
-        Assert.assertEquals("validation count should match", 0, validationCount.get());
+        Assert.assertEquals("validation count should match", 1001, validationCount.get());
+    }
+
+    /**
+     * Validates cleanup aspect of validation
+     */
+    @Test
+    public final void testOneSyncValidatorCleanup() throws Exception {
+        AtomicInteger opCount = new AtomicInteger();
+        AtomicInteger validationCount = new AtomicInteger();
+
+        IncrementOperation op = new IncrementOperation(opCount);
+        op.addValidator(new IncrementSyncValidator(validationCount));
+
+        op.execute();
+        Assert.assertEquals("operation count should match", 1, opCount.get());
+        Assert.assertEquals("validation count should match", 1, validationCount.get());
+
+        op.close();
+        Assert.assertEquals("operation count should match", 0, opCount.get());
+        Assert.assertEquals("validation count should match", 1001, validationCount.get());
+    }
+
+    /**
+     * Validates cleanup aspect of validation
+     */
+    @Test
+    public final void testOneAsyncValidatorCleanup() throws Exception {
+        AtomicInteger opCount = new AtomicInteger();
+        AtomicInteger validationCount = new AtomicInteger();
+
+        IncrementOperation op = new IncrementOperation(opCount);
+        op.addValidator(new IncrementAsyncValidator(validationCount));
+
+        op.execute();
+        Assert.assertEquals("operation count should match", 1, opCount.get());
+        Assert.assertEquals("validation count should match", 1, validationCount.get());
+
+        op.close();
+        Assert.assertEquals("operation count should match", 0, opCount.get());
+        Assert.assertEquals("validation count should match", 1001, validationCount.get());
     }
 
     /**


### PR DESCRIPTION
This method will be called on validators when the operation execution succeeded,
but revert failed.  Normally in that situation the validator would not be called.

Also, fixed comments in the Validator interface.

Resolves: #6