### PR TITLE
Improve handling of java.lang.Error in operations and validators

### DIFF
--- a/test-operations/src/main/java/com/vmware/operations/Operation.java
+++ b/test-operations/src/main/java/com/vmware/operations/Operation.java
@@ -79,9 +79,9 @@ public interface Operation extends AutoCloseable {
      * Throws an error on failure.
      * When the execution has completed, isExecuted() will return true.
      *
-     * @throws Exception if the operation fails
+     * @throws Throwable if the operation fails
      */
-    void execute() throws Exception;
+    void execute() throws Throwable;
 
     /**
      * Perform the command.
@@ -96,9 +96,9 @@ public interface Operation extends AutoCloseable {
      * Throws an IllegalStateException on failure.
      * When the revert has completed, isExecuted() will return false.
      *
-     * @throws Exception if the revert operation fails
+     * @throws Throwable if the revert operation fails
      */
-    void revert() throws Exception;
+    void revert() throws Throwable;
 
     /**
      * "Un-perform" a command.

--- a/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
@@ -59,9 +59,9 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
      * This ensures that it will be cleaned up when this list is reverted/cleaned up.
      *
      * @param cmd the command to run
-     * @throws Exception if the execution cannot be completed
+     * @throws Throwable if the execution cannot be completed
      */
-    public void addExecute(Operation cmd) throws Exception {
+    public void addExecute(Operation cmd) throws Throwable {
         data.add(cmd);
         cmd.execute();
     }
@@ -119,7 +119,7 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
      * each one to complete before starting the next.
      */
     @Override
-    public void executeImpl() throws Exception {
+    public void executeImpl() throws Throwable {
         finish();
 
         logger.info("Executing {}", toString());
@@ -141,7 +141,7 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
      * operations where undone explicitly.
      */
     @Override
-    public void revertImpl() throws Exception {
+    public void revertImpl() throws Throwable {
         finish();
 
         logger.info("Reverting {}", toString());

--- a/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
@@ -38,7 +38,7 @@ public abstract class OperationSyncBase extends OperationBase {
     }
 
     @Override
-    public final void execute() throws Exception {
+    public final void execute() throws Throwable {
         executeImpl();
 
         // Unwrap the async exceptions
@@ -47,8 +47,8 @@ public abstract class OperationSyncBase extends OperationBase {
         } catch (ExecutionException ex) {
             // Unwrap the exception if possible
             Throwable cause = ex.getCause();
-            if (cause instanceof Exception) {
-                throw (Exception) cause;
+            if (cause != null) {
+                throw cause;
             } else {
                 throw ex;
             }
@@ -63,8 +63,8 @@ public abstract class OperationSyncBase extends OperationBase {
                 try {
                     executeImpl();
                     executionResult.complete(null);
-                } catch (Exception ex) {
-                    executionResult.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    executionResult.completeExceptionally(th);
                 }
             });
         } catch (Exception ex) {
@@ -77,7 +77,7 @@ public abstract class OperationSyncBase extends OperationBase {
     }
 
     @Override
-    public final void revert() throws Exception {
+    public final void revert() throws Throwable {
         revertImpl();
 
         // Unwrap the async exceptions
@@ -86,8 +86,8 @@ public abstract class OperationSyncBase extends OperationBase {
         } catch (ExecutionException ex) {
             // Unwrap the exception if possible
             Throwable cause = ex.getCause();
-            if (cause instanceof Exception) {
-                throw (Exception) cause;
+            if (cause != null) {
+                throw cause;
             } else {
                 throw ex;
             }
@@ -102,8 +102,8 @@ public abstract class OperationSyncBase extends OperationBase {
                 try {
                     revertImpl();
                     revertResult.complete(null);
-                } catch (Exception ex) {
-                    revertResult.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    revertResult.completeExceptionally(th);
                 }
             });
         } catch (Exception ex) {
@@ -146,8 +146,8 @@ public abstract class OperationSyncBase extends OperationBase {
                 try {
                     cleanup();
                     result.complete(null);
-                } catch (Exception ex) {
-                    result.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    result.completeExceptionally(th);
                 }
             });
         } catch (Exception ex) {
@@ -165,13 +165,13 @@ public abstract class OperationSyncBase extends OperationBase {
      * Synchronous implementation of the operation.
      * @throws Exception if the operation cannot be completed
      */
-    public abstract void executeImpl() throws Exception;
+    public abstract void executeImpl() throws Throwable;
 
     /**
      * Synchronous revert implementation of the operation.
      * @throws Exception if the operation cannot be reverted
      */
-    public abstract void revertImpl() throws Exception;
+    public abstract void revertImpl() throws Throwable;
 
     @Override
     public abstract String toString();

--- a/test-operations/src/main/java/com/vmware/operations/ValidatorAsyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/ValidatorAsyncBase.java
@@ -36,9 +36,9 @@ public abstract class ValidatorAsyncBase<T extends Operation> implements Validat
             @SuppressWarnings({"unchecked"})
             T expectedInitiatingOp = (T) initiatingOp;
             return validateExecution(executorService, expectedInitiatingOp);
-        } catch (Exception ex) {
+        } catch (Throwable th) {
             CompletableFuture<Void> result = new CompletableFuture<>();
-            result.completeExceptionally(ex);
+            result.completeExceptionally(th);
             return result;
         }
 
@@ -51,9 +51,9 @@ public abstract class ValidatorAsyncBase<T extends Operation> implements Validat
             @SuppressWarnings({"unchecked"})
             T expectedInitiatingOp = (T) initiatingOp;
             return validateRevert(executorService, expectedInitiatingOp);
-        } catch (Exception ex) {
+        } catch (Throwable th) {
             CompletableFuture<Void> result = new CompletableFuture<>();
-            result.completeExceptionally(ex);
+            result.completeExceptionally(th);
             return result;
         }
     }

--- a/test-operations/src/main/java/com/vmware/operations/ValidatorSyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/ValidatorSyncBase.java
@@ -40,12 +40,12 @@ public abstract class ValidatorSyncBase<T> implements Validator {
                     T expectedInitiatingOp = (T) initiatingOp;
                     validateExecution(expectedInitiatingOp);
                     executeResult.complete(null);
-                } catch (Exception ex) {
-                    executeResult.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    executeResult.completeExceptionally(th);
                 }
             });
-        } catch (Exception ex) {
-            executeResult.completeExceptionally(ex);
+        } catch (Throwable th) {
+            executeResult.completeExceptionally(th);
         }
 
         return executeResult;
@@ -62,12 +62,12 @@ public abstract class ValidatorSyncBase<T> implements Validator {
                     T expectedInitiatingOp = (T) initiatingOp;
                     validateRevert(expectedInitiatingOp);
                     executeResult.complete(null);
-                } catch (Exception ex) {
-                    executeResult.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    executeResult.completeExceptionally(th);
                 }
             });
-        } catch (Exception ex) {
-            executeResult.completeExceptionally(ex);
+        } catch (Throwable th) {
+            executeResult.completeExceptionally(th);
         }
 
         return executeResult;
@@ -84,12 +84,12 @@ public abstract class ValidatorSyncBase<T> implements Validator {
                     T expectedInitiatingOp = (T) initiatingOp;
                     validateCleanup(expectedInitiatingOp);
                     executeResult.complete(null);
-                } catch (Exception ex) {
-                    executeResult.completeExceptionally(ex);
+                } catch (Throwable th) {
+                    executeResult.completeExceptionally(th);
                 }
             });
-        } catch (Exception ex) {
-            executeResult.completeExceptionally(ex);
+        } catch (Throwable th) {
+            executeResult.completeExceptionally(th);
         }
 
         return executeResult;

--- a/test-operations/src/test/java/com/vmware/example/ExampleTest.java
+++ b/test-operations/src/test/java/com/vmware/example/ExampleTest.java
@@ -51,7 +51,7 @@ public class ExampleTest {
      * @throws Exception
      */
     @Test
-    public void closeableOperationTest() throws Exception {
+    public void closeableOperationTest() throws Throwable {
         try (CreateFileOp local = new CreateFileOp("foo.txt")) {
             local.execute();
             local.revert();
@@ -128,7 +128,7 @@ public class ExampleTest {
      */
 
     @Test
-    public void scriptedTest() throws Exception {
+    public void scriptedTest() throws Throwable {
         try (Operation ops = Operations.list()) {
             for (int i = 0; i < 10; ++i) {
                 OperationSequence seq = Operations.sequence();

--- a/test-operations/src/test/java/com/vmware/operations/OperationFailureTest.java
+++ b/test-operations/src/test/java/com/vmware/operations/OperationFailureTest.java
@@ -38,7 +38,7 @@ public class OperationFailureTest extends OperationTestBase {
 
         @Override
         public void executeImpl() {
-            throw new ArithmeticException("execute");
+            throw new AssertionError("execute");
         }
     }
 
@@ -49,7 +49,7 @@ public class OperationFailureTest extends OperationTestBase {
 
         @Override
         public void revertImpl() {
-            throw new ArithmeticException("revert");
+            throw new AssertionError("revert");
         }
     }
 
@@ -60,7 +60,7 @@ public class OperationFailureTest extends OperationTestBase {
 
         @Override
         public void cleanup() {
-            throw new ArithmeticException("cleanup");
+            throw new AssertionError("cleanup");
         }
     }
 
@@ -75,7 +75,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             cmd.execute();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -107,7 +107,7 @@ public class OperationFailureTest extends OperationTestBase {
      * @throws Exception if an operation throws during execution
      */
     @Test
-    public final void testBasicRevertFailure() throws Exception {
+    public final void testBasicRevertFailure() throws Throwable {
         AtomicInteger value = new AtomicInteger(0);
         Operation cmd = new RevertFailure(value);
 
@@ -118,7 +118,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             cmd.revert();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -139,7 +139,7 @@ public class OperationFailureTest extends OperationTestBase {
      * @throws Exception if an operation throws during execution
      */
     @Test
-    public final void testBasicCleanupFailure() throws Exception {
+    public final void testBasicCleanupFailure() throws Throwable {
         AtomicInteger value = new AtomicInteger(0);
         Operation cmd = new CleanupFailure(value);
 
@@ -150,7 +150,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             cmd.close();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -163,7 +163,7 @@ public class OperationFailureTest extends OperationTestBase {
      * Verify that failures in the execute() method are handled properly.
      */
     @Test
-    public final void testDoubleExecuteFailure() throws Exception {
+    public final void testDoubleExecuteFailure() throws Throwable {
         AtomicInteger value = new AtomicInteger(0);
         Operation cmd = new IncrementOperation(value);
 
@@ -209,7 +209,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             seq.execute();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -236,10 +236,10 @@ public class OperationFailureTest extends OperationTestBase {
      * This means that they don't resolve to isExecuted state as false, but are
      * still capable of cleaning up.
      *
-     * @throws Exception if an operation throws during execution
+     * @throws Throwable if an operation throws during execution
      */
     @Test
-    public final void testSequenceRevertFailure() throws Exception {
+    public final void testSequenceRevertFailure() throws Throwable {
         OperationSequence seq = Operations.sequence();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -255,7 +255,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             seq.revert();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -272,10 +272,10 @@ public class OperationFailureTest extends OperationTestBase {
      * This means that they clean up as cleanly as possible, but don't
      * throw errors.
      *
-     * @throws Exception if an operation throws during execution
+     * @throws Throwable if an operation throws during execution
      */
     @Test
-    public final void testSequenceCleanupFailure() throws Exception {
+    public final void testSequenceCleanupFailure() throws Throwable {
         OperationSequence seq = Operations.sequence();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -311,7 +311,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             list.execute();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -339,10 +339,10 @@ public class OperationFailureTest extends OperationTestBase {
      * This means that they don't resolve to isExecuted state as false, but are
      * still capable of cleaning up.
      *
-     * @throws Exception if an operation throws during execution
+     * @throws Throwable if an operation throws during execution
      */
     @Test
-    public final void testParallelRevertFailure() throws Exception {
+    public final void testParallelRevertFailure() throws Throwable {
         OperationList list = Operations.list();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -357,7 +357,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             list.revert();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // This is the expected case
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -376,10 +376,10 @@ public class OperationFailureTest extends OperationTestBase {
      * This means that they clean up as cleanly as possible, but don't
      * throw errors.
      *
-     * @throws Exception if an operation throws during execution
+     * @throws Throwable if an operation throws during execution
      */
     @Test
-    public final void testParallelCleanupFailure() throws Exception {
+    public final void testParallelCleanupFailure() throws Throwable {
         OperationList list = Operations.list();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -416,7 +416,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             seq.execute();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -448,7 +448,7 @@ public class OperationFailureTest extends OperationTestBase {
      * @throws Exception if an operation throws during execution
      */
     @Test
-    public final void testParallelRevertFailureWorstCase() throws Exception {
+    public final void testParallelRevertFailureWorstCase() throws Throwable {
         OperationList list = Operations.list();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -463,7 +463,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             list.revert();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // This is the expected case
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);
@@ -486,7 +486,7 @@ public class OperationFailureTest extends OperationTestBase {
      * @throws Exception if an operation throws during execution
      */
     @Test
-    public final void testParallelCleanupFailureWorstCase() throws Exception {
+    public final void testParallelCleanupFailureWorstCase() throws Throwable {
         OperationList list = Operations.list();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -512,7 +512,7 @@ public class OperationFailureTest extends OperationTestBase {
      * still capable of cleaning up.
      */
     @Test
-    public final void testParallelExecutePartialSuccess() throws Exception {
+    public final void testParallelExecutePartialSuccess() throws Throwable {
         OperationList list = Operations.list();
 
         AtomicInteger value = new AtomicInteger(0);
@@ -557,7 +557,7 @@ public class OperationFailureTest extends OperationTestBase {
         try {
             list.execute();
             Assert.fail("Exception was not thrown");
-        } catch (ArithmeticException expected) {
+        } catch (AssertionError expected) {
             // Expected
         } catch (Throwable t) {
             Assert.fail("Unexpected exception type thrown: " + t);

--- a/test-operations/src/test/java/com/vmware/operations/OperationTest.java
+++ b/test-operations/src/test/java/com/vmware/operations/OperationTest.java
@@ -54,7 +54,7 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
-    public final void testSequenceBasic() throws Exception {
+    public final void testSequenceBasic() throws Throwable {
         final long delayMillis = 100;
         OperationSequence seq = Operations.sequence();
 
@@ -101,7 +101,7 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
-    public final void testParallelBasic() throws Exception {
+    public final void testParallelBasic() throws Throwable {
         final long delayMillis = 200;
         OperationCollection list = Operations.list();
 
@@ -157,7 +157,7 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
-    public final void testSingleThreadedParallel() throws Exception {
+    public final void testSingleThreadedParallel() throws Throwable {
         final long delayMillis = 200;
         Operations.setExecutorService(Executors.newSingleThreadExecutor());
         try {
@@ -232,7 +232,7 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
-    public final void testSequenceScale() throws Exception {
+    public final void testSequenceScale() throws Throwable {
         AtomicInteger value = new AtomicInteger(1);
 
         try (OperationSequence seq = Operations.sequence()) {
@@ -264,7 +264,7 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
-    public final void testParallelScale() throws Exception {
+    public final void testParallelScale() throws Throwable {
         AtomicInteger value = new AtomicInteger(0);
 
         try (OperationCollection seq = Operations.list()) {


### PR DESCRIPTION
Throwing Assertions (subclass of Error) instead of ArithmeticException (subclass of Exception) exposed all sorts of problems.

Catch Throwables throughout the code to correct the problem.  This will result in a major version change, since the signatures of all the methods have changed.

Added tests for more configurations of sync and async operations against sync and async validations to ensure correct behavior.

Resolves #10