### PR TITLE
Add delayOp

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It's easy to get started adding operations to your Java project.  Just add to yo
 <dependency>
   <groupId>com.vmware.test-operations</groupId>
   <artifactId>test-operations</artifactId>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/test-operations/src/main/java/com/vmware/operations/DelayOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/DelayOp.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic operation implementation that uses dynamic function calls
  * for execute and revert.
- * <p/>
+ * <p>
  * This allows for dynamic operations, or linking two operations together.
  */
 public class DelayOp extends OperationSyncBase {
@@ -51,6 +51,8 @@ public class DelayOp extends OperationSyncBase {
 
     /**
      * Alternate constructor for the most basic case of delaying the execution.
+     *
+     * @param d delay time expressed as a {@link java.time.Duration}
      */
     public DelayOp(Duration d) {
         super(Operations.getExecutorService());

--- a/test-operations/src/main/java/com/vmware/operations/DelayOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/DelayOp.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2015-2018 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.operations;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A generic operation implementation that uses dynamic function calls
+ * for execute and revert.
+ * <p/>
+ * This allows for dynamic operations, or linking two operations together.
+ */
+public class DelayOp extends OperationSyncBase {
+    private final static Logger logger = LoggerFactory.getLogger(DelayOp.class);
+
+    // Maximum delay is 100 minutes
+    private final long maximumDelayMs = 100 * 60 * 1000L;
+
+    private long executeDelayMs;
+    private long revertDelayMs;
+    private AtomicBoolean isExecuted = new AtomicBoolean();
+
+    /**
+     * Constructor of the delay operation.
+     */
+    public DelayOp() {
+        super(Operations.getExecutorService());
+        executeDelayMs = 0L;
+        revertDelayMs = 0L;
+    }
+
+    /**
+     * Alternate constructor for the most basic case of delaying the execution.
+     */
+    public DelayOp(Duration d) {
+        super(Operations.getExecutorService());
+
+        this.executeDelay(d);
+        revertDelayMs = 0L;
+    }
+
+    /**
+     * Set the delay during execution.
+     *
+     * @param d delay time expressed as a {@link java.time.Duration}
+     * @return fluent operation returns itself
+     */
+    public DelayOp executeDelay(Duration d) {
+        long millis = d.toMillis();
+        if (millis < 0L || millis > maximumDelayMs) {
+            throw new IllegalArgumentException("delay must be between 0 and " + maximumDelayMs + " ms");
+        }
+        this.executeDelayMs = millis;
+        return this;
+    }
+
+    /**
+     * Set the delay during revert.
+     *
+     * @param d delay time expressed as a {@link java.time.Duration}
+     * @return fluent operation returns itself
+     */
+    public DelayOp revertDelay(Duration d) {
+        long millis = d.toMillis();
+        if (millis < 0L || millis > maximumDelayMs) {
+            throw new IllegalArgumentException("delay must be between 0 and " + maximumDelayMs + " ms");
+        }
+        this.revertDelayMs = millis;
+        return this;
+    }
+
+    @Override
+    public boolean isExecuted() {
+        return isExecuted.get();
+    }
+
+    @Override
+    public void executeImpl() throws InterruptedException {
+        logger.info("Executing {} for {} ms", toString(), executeDelayMs);
+
+        throwIfExecuted();
+        if (executeDelayMs > 0L) {
+            Thread.sleep(executeDelayMs);
+        }
+
+        if (!isExecuted.compareAndSet(false, true)) {
+            throw new AssertionError("Error setting isExecuted true");
+        }
+    }
+
+    @Override
+    public void revertImpl() throws InterruptedException {
+        logger.info("Executing {} for {} ms", toString(), revertDelayMs);
+
+        throwIfNotExecuted();
+        if (revertDelayMs > 0) {
+            Thread.sleep(revertDelayMs);
+        }
+
+        if (!isExecuted.compareAndSet(true, false)) {
+            throw new AssertionError("Error setting isExecuted false");
+        }
+    }
+
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/test-operations/src/main/java/com/vmware/operations/DelayOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/DelayOp.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * This allows for dynamic operations, or linking two operations together.
  */
 public class DelayOp extends OperationSyncBase {
-    private final static Logger logger = LoggerFactory.getLogger(DelayOp.class);
+    private static final Logger logger = LoggerFactory.getLogger(DelayOp.class);
 
     // Maximum delay is 100 minutes
     private final long maximumDelayMs = 100 * 60 * 1000L;

--- a/test-operations/src/main/java/com/vmware/operations/GenericOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/GenericOp.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic operation implementation that uses dynamic function calls
  * for execute and revert.
- * <p/>
+ * <p>
  * This allows for dynamic operations, or linking two operations together.
  */
 public class GenericOp<T> extends OperationSyncBase {

--- a/test-operations/src/main/java/com/vmware/operations/GenericOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/GenericOp.java
@@ -20,9 +20,7 @@ package com.vmware.operations;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * This allows for dynamic operations, or linking two operations together.
  */
 public class GenericOp<T> extends OperationSyncBase {
-    private final static Logger logger = LoggerFactory.getLogger(GenericOp.class);
+    private static final Logger logger = LoggerFactory.getLogger(GenericOp.class);
 
     private String name;
     private T data;
@@ -148,7 +146,7 @@ public class GenericOp<T> extends OperationSyncBase {
                 }
                 uncalledRevertFunctions.removeFirst();
             }
-
+ø
             uncalledRevertFunctions = null;
         }
     }

--- a/test-operations/src/main/java/com/vmware/operations/GenericOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/GenericOp.java
@@ -146,7 +146,7 @@ public class GenericOp<T> extends OperationSyncBase {
                 }
                 uncalledRevertFunctions.removeFirst();
             }
-ø
+
             uncalledRevertFunctions = null;
         }
     }

--- a/test-operations/src/main/java/com/vmware/operations/OperationAsyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationAsyncBase.java
@@ -38,6 +38,11 @@ public abstract class OperationAsyncBase extends OperationBase {
 
     private final ExecutorService executorService;
 
+    protected OperationAsyncBase() {
+        super();
+        this.executorService = Operations.getExecutorService();
+    }
+
     protected OperationAsyncBase(ExecutorService executorService) {
         super();
         this.executorService = executorService;

--- a/test-operations/src/main/java/com/vmware/operations/OperationList.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationList.java
@@ -90,7 +90,9 @@ public class OperationList extends OperationAsyncBase implements OperationCollec
 
     @Override
     public void add(Operation op) {
-        operations.add(op);
+        if (op != null) {
+            operations.add(op);
+        }
     }
 
     @Override

--- a/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
@@ -51,7 +51,9 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
      * @param cmd the command to run
      */
     public void add(Operation cmd) {
-        data.add(cmd);
+        if (cmd != null) {
+            data.add(cmd);
+        }
     }
 
     /**
@@ -62,8 +64,10 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
      * @throws Throwable if the execution cannot be completed
      */
     public void addExecute(Operation cmd) throws Throwable {
-        data.add(cmd);
-        cmd.execute();
+        if (cmd != null) {
+            data.add(cmd);
+            cmd.execute();
+        }
     }
 
     /**

--- a/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSyncBase.java
@@ -32,6 +32,11 @@ import java.util.concurrent.ExecutorService;
 public abstract class OperationSyncBase extends OperationBase {
     private final ExecutorService executorService;
 
+    protected OperationSyncBase() {
+        super();
+        this.executorService = Operations.getExecutorService();
+    }
+
     protected OperationSyncBase(ExecutorService executorService) {
         super();
         this.executorService = executorService;

--- a/test-operations/src/test/java/com/vmware/operations/DelayOpTests.java
+++ b/test-operations/src/test/java/com/vmware/operations/DelayOpTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2015-2018 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.operations;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the Operations classes, ensuring that they behave correctly.
+ */
+public class DelayOpTests {
+    private final static Logger logger = LoggerFactory.getLogger(DelayOpTests.class);
+
+    @Test
+    public void defaultConstructor() throws Throwable {
+        DelayOp op = new DelayOp();
+
+        long startTime = System.nanoTime();
+        op.execute();
+        op.revert();
+
+        long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + 1;
+        logger.info("Execution time: {} ms", executionTime);
+
+        Assert.assertTrue("Execution time was slower than expected: " + executionTime,
+                executionTime < 100);
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     *
+     * @throws Exception for unexpected exceptions
+     */
+    @Test
+    public void alternateConstructor() throws Throwable {
+        DelayOp op = new DelayOp(Duration.ofSeconds(1));
+
+        long startTime = System.nanoTime();
+        op.execute();
+        op.revert();
+
+        long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + 1;
+        logger.info("Execution time: {} ms", executionTime);
+
+        Assert.assertTrue("Execution time was faster than expected: " + executionTime,
+                executionTime >= 1000);
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     *
+     * @throws Exception for unexpected exceptions
+     */
+    @Test
+    public final void delayMutators() throws Throwable {
+        DelayOp op = new DelayOp()
+                .executeDelay(Duration.ofSeconds(1))
+                .revertDelay(Duration.ofSeconds(1));
+
+        long startTime = System.nanoTime();
+        op.execute();
+
+        long executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + 1;
+        logger.info("Execution time: {} ms", executionTime);
+
+        Assert.assertTrue("Execution time was faster than expected: " + executionTime,
+                executionTime >= 1000);
+
+        op.revert();
+
+        executionTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + 1;
+        logger.info("Execution time: {} ms", executionTime);
+
+        Assert.assertTrue("Execution time was faster than expected: " + executionTime,
+                executionTime >= 2000);
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public final void negativeConstructorDelay() throws Throwable {
+        DelayOp op = new DelayOp(Duration.ofSeconds(-1));
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public final void negativeExecutorDelay() throws Throwable {
+        DelayOp op = new DelayOp()
+                .executeDelay(Duration.ofSeconds(-1));
+    }
+
+    /**
+     * Test method for {@link OperationList}.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public final void negativeRevertDelay() throws Throwable {
+        DelayOp op = new DelayOp()
+                .revertDelay(Duration.ofSeconds(-1));
+    }
+}

--- a/test-operations/src/test/java/com/vmware/operations/GenericOpTests.java
+++ b/test-operations/src/test/java/com/vmware/operations/GenericOpTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2015-2018 VMware, Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vmware.operations;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the Operations classes, ensuring that they behave correctly.
+ */
+public class GenericOpTests {
+    private final static Logger logger = LoggerFactory.getLogger(GenericOpTests.class);
+
+    @Test
+    public void empty() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>(new AtomicInteger(1));
+
+        op.execute();
+        op.revert();
+
+        Assert.assertEquals(1, op.getData().get());
+    }
+
+    @Test
+    public void named() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>("name", new AtomicInteger(1));
+
+        op.execute();
+        op.revert();
+
+        Assert.assertEquals(1, op.getData().get());
+    }
+
+    @Test
+    public void basicTest() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>(new AtomicInteger(1));
+
+        op.addExecuteFunction(v -> v.getAndUpdate(x -> x * 31));
+        op.addExecuteFunction(v -> v.getAndIncrement());
+
+        op.addRevertFunction(v -> v.getAndUpdate(x -> x * 7));
+        op.addRevertFunction(v -> v.getAndDecrement());
+
+        op.execute();
+
+        // If done in the correct order, the answer is (1 * 31) + 1 = 32
+        Assert.assertEquals(32, op.getData().get());
+
+        op.revert();
+
+        // If done in the correct order, the answer is (32 - 1) * 7 = 217
+        Assert.assertEquals(217, op.getData().get());
+    }
+
+    @Test
+    public void executeFailureTest() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>(new AtomicInteger(1));
+
+        op.addExecuteFunction(v -> v.getAndUpdate(x -> x * 31));
+        op.addExecuteFunction(v -> { throw new IllegalArgumentException(); });
+        op.addExecuteFunction(v -> v.getAndIncrement());
+
+        op.addRevertFunction(v -> v.getAndUpdate(x -> x * 7));
+
+        try {
+            op.execute();
+            throw new AssertionError("Exception not thrown");
+        } catch (IllegalArgumentException ia) {
+            // expected exception
+        }
+
+        // If done in the correct order, the answer is (1 * 31) + 1 = 32
+        Assert.assertEquals(31, op.getData().get());
+
+        op.cleanup();
+
+        // Revert functions should not have been called
+        Assert.assertEquals(31, op.getData().get());
+    }
+
+    @Test
+    public void revertFailureTest() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>(new AtomicInteger(1));
+
+        op.addExecuteFunction(v -> v.getAndUpdate(x -> x * 31));
+        op.addExecuteFunction(v -> v.getAndIncrement());
+
+        op.addRevertFunction(v -> v.getAndUpdate(x -> x * 7));
+        op.addRevertFunction(v -> { throw new IllegalArgumentException(); });
+        op.addRevertFunction(v -> v.getAndDecrement());
+
+        op.execute();
+
+        // If done in the correct order, the answer is (1 * 31) + 1 = 32
+        Assert.assertEquals(32, op.getData().get());
+
+        try {
+            op.revert();
+            throw new AssertionError("Exception not thrown");
+        } catch (IllegalArgumentException ia) {
+            // expected exception
+        }
+
+        // If done in the correct order, the answer is (32 - 1) = 31
+        Assert.assertEquals(31, op.getData().get());
+
+        op.cleanup();
+
+        // Cleanup should get the masked revert function, the answer is (32 - 1) = 217
+        Assert.assertEquals(217, op.getData().get());
+    }
+
+    @Test
+    public void cleanupFailureTest() throws Throwable {
+        GenericOp<AtomicInteger> op = new GenericOp<>(new AtomicInteger(1));
+
+        op.addExecuteFunction(v -> v.getAndUpdate(x -> x * 31));
+        op.addExecuteFunction(v -> v.getAndIncrement());
+
+        op.addRevertFunction(v -> v.getAndUpdate(x -> x * 7));
+        op.addRevertFunction(v -> { throw new IllegalArgumentException(); });
+        op.addRevertFunction(v -> v.getAndDecrement());
+
+        op.execute();
+
+        // If done in the correct order, the answer is (1 * 31) + 1 = 32
+        Assert.assertEquals(32, op.getData().get());
+
+        op.cleanup();
+
+        // All functions will be attempted
+        Assert.assertEquals(217, op.getData().get());
+    }
+}

--- a/test-operations/src/test/java/com/vmware/operations/IncrementAsyncOperation.java
+++ b/test-operations/src/test/java/com/vmware/operations/IncrementAsyncOperation.java
@@ -46,7 +46,6 @@ public class IncrementAsyncOperation extends OperationAsyncBase {
      * @param data AtomicInteger container
      */
     public IncrementAsyncOperation(AtomicInteger data) {
-        super(Operations.getExecutorService());
         Assert.assertNotNull(data);
         this.data = data;
     }

--- a/test-operations/src/test/java/com/vmware/operations/IncrementOperation.java
+++ b/test-operations/src/test/java/com/vmware/operations/IncrementOperation.java
@@ -43,7 +43,6 @@ public class IncrementOperation extends OperationSyncBase {
      * @param data AtomicInteger container
      */
     public IncrementOperation(AtomicInteger data) {
-        super(Operations.getExecutorService());
         Assert.assertNotNull(data);
         this.data = data;
     }

--- a/test-operations/src/test/java/com/vmware/operations/OperationTest.java
+++ b/test-operations/src/test/java/com/vmware/operations/OperationTest.java
@@ -54,6 +54,22 @@ public class OperationTest {
      * @throws Exception for unexpected exceptions
      */
     @Test
+    public final void testSequenceNull() throws Throwable {
+        OperationSequence seq = Operations.sequence();
+        seq.add(null);
+        seq.addExecute(null);
+
+        Assert.assertTrue(seq.isEmpty());
+
+        seq.close();
+    }
+
+    /**
+     * Test method for {@link com.vmware.operations.Operation}.
+     *
+     * @throws Exception for unexpected exceptions
+     */
+    @Test
     public final void testSequenceBasic() throws Throwable {
         final long delayMillis = 100;
         OperationSequence seq = Operations.sequence();
@@ -93,6 +109,21 @@ public class OperationTest {
                 executionTime >= seq.size() * delayMillis);
 
         seq.close();
+    }
+
+    /**
+     * Test method for {@link com.vmware.operations.Operation}.
+     *
+     * @throws Exception for unexpected exceptions
+     */
+    @Test
+    public final void testParallelNull() throws Throwable {
+        OperationCollection list = Operations.list();
+        list.add(null);
+
+        Assert.assertTrue(list.isEmpty());
+
+        list.close();
     }
 
     /**


### PR DESCRIPTION
Several changes:

Added a general-purpose operation that just introduces a delay between other operations.  This serves
as a good exmaple implementation.

Moved GenericOp from the test-jar to the compile-jar.  Added tests to verify (and improve) functionality

Added no-arg constructors to base implementations.  This should make it a little easier to write base classes.

Added null check to OperationList.add and OperationSequence.add.  This addresses a discussion in https://github.com/vmware/test-operations/issues/13