### PR TITLE
Update the dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vmware.test-operations</groupId>
     <artifactId>test-operations-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -39,12 +39,12 @@
     <scm>
         <connection>scm:git:https://github.com/vmware/test-operations.git</connection>
         <url>https://github.com/vmware/test-operations</url>
-      <tag>test-operations-parent-1.0.0</tag>
+        <tag>test-operations-parent-1.2.0</tag>
     </scm>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -62,10 +62,10 @@
           <configuration>
             <rules>
               <requireMavenVersion>
-                <version>[3.3.9,)</version>
+                <version>[3.6.3,)</version>
               </requireMavenVersion>
               <requireJavaVersion>
-                <version>1.8</version>
+                <version>1.11</version>
               </requireJavaVersion>
             </rules>
             <fail>true</fail>
@@ -85,7 +85,7 @@
         -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.2.5</version>
           <executions>
             <execution>
               <id>default-test</id>
@@ -104,7 +104,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.6</version>
+          <version>0.8.11</version>
           <executions>
             <execution>
               <id>default-prepare-agent</id>
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
+            <version>1.16.0</version>
         </dependency>
 
         <!-- Test only JARs -->
@@ -166,25 +166,25 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>[7.7.0,)</version>
+            <version>[7.9.0,)</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
       </dependencies>
@@ -210,7 +210,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>3.0.0</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>validate</id>
@@ -232,7 +232,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.7.3.0</version>
+                        <version>4.8.3.0</version>
                         <configuration>
                             <effort>High</effort>
                             <threshold>Default</threshold>
@@ -250,7 +250,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -302,7 +302,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.3</version>
+                        <version>3.0.1</version>
                     </plugin>
 
                     <!--
@@ -311,7 +311,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -328,7 +328,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -346,7 +346,7 @@
                     <plugin>
                       <groupId>org.sonatype.plugins</groupId>
                       <artifactId>nexus-staging-maven-plugin</artifactId>
-                      <version>1.6.8</version>
+                      <version>1.6.13</version>
                       <extensions>true</extensions>
                       <configuration>
                         <serverId>ossrh</serverId>

--- a/test-operations/pom.xml
+++ b/test-operations/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.vmware.test-operations</groupId>
     <artifactId>test-operations-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>test-operations</artifactId>
   <!--
@@ -67,6 +67,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>4.7.3</version>
     </dependency>
   </dependencies>
 

--- a/test-operations/src/main/java/com/vmware/operations/DelayOp.java
+++ b/test-operations/src/main/java/com/vmware/operations/DelayOp.java
@@ -34,7 +34,7 @@ public class DelayOp extends OperationSyncBase {
     private static final Logger logger = LoggerFactory.getLogger(DelayOp.class);
 
     // Maximum delay is 100 minutes
-    private final long maximumDelayMs = 100 * 60 * 1000L;
+    private static final long maximumDelayMs = 100 * 60 * 1000L;
 
     private long executeDelayMs;
     private long revertDelayMs;
@@ -69,11 +69,23 @@ public class DelayOp extends OperationSyncBase {
      */
     public DelayOp executeDelay(Duration d) {
         long millis = d.toMillis();
-        if (millis < 0L || millis > maximumDelayMs) {
-            throw new IllegalArgumentException("delay must be between 0 and " + maximumDelayMs + " ms");
+        if (millis < 0L) {
+            logger.error("delay must be greater than 0 ms.");
+            millis = 0;
+        } else if (millis > maximumDelayMs) {
+            logger.error("delay must be less than " + maximumDelayMs + " ms.");
+            millis = maximumDelayMs;
         }
         this.executeDelayMs = millis;
         return this;
+    }
+
+    /**
+     * Get the delay during execution.
+     * @return Duration value for the execution delay
+     */
+    public Duration getExecuteDelay() {
+        return Duration.ofMillis(executeDelayMs);
     }
 
     /**
@@ -84,11 +96,23 @@ public class DelayOp extends OperationSyncBase {
      */
     public DelayOp revertDelay(Duration d) {
         long millis = d.toMillis();
-        if (millis < 0L || millis > maximumDelayMs) {
-            throw new IllegalArgumentException("delay must be between 0 and " + maximumDelayMs + " ms");
+        if (millis < 0L) {
+            logger.error("delay must be greater than 0 ms.");
+            millis = 0;
+        } else if (millis > maximumDelayMs) {
+            logger.error("delay must be less than " + maximumDelayMs + " ms.");
+            millis = maximumDelayMs;
         }
         this.revertDelayMs = millis;
         return this;
+    }
+
+    /**
+     * Get the delay during revert.
+     * @return Duration value for the revert delay
+     */
+    public Duration getRevertDelay() {
+        return Duration.ofMillis(revertDelayMs);
     }
 
     @Override

--- a/test-operations/src/main/java/com/vmware/operations/OperationList.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationList.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +108,12 @@ public class OperationList extends OperationAsyncBase implements OperationCollec
         return operations.size();
     }
 
+    /*
+     * Suppress Spotbugs warning because we make the list immutable at
+     * finish() time.
+     */
     @Override
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public List<Operation> getOperations() {
         return operations;
     }

--- a/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
+++ b/test-operations/src/main/java/com/vmware/operations/OperationSequence.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +85,12 @@ public class OperationSequence extends OperationSyncBase implements OperationCol
         return data.size();
     }
 
+    /*
+     * Suppress Spotbugs warning because we make the list immutable at
+     * finish() time.
+     */
     @Override
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public List<Operation> getOperations() {
         return data;
     }

--- a/test-operations/src/test/java/com/vmware/operations/DelayOpTests.java
+++ b/test-operations/src/test/java/com/vmware/operations/DelayOpTests.java
@@ -99,26 +99,64 @@ public class DelayOpTests {
     /**
      * Test method for {@link Operation}.
      */
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public final void negativeConstructorDelay() throws Throwable {
+    @Test
+    public final void negativeConstructorDelay() {
         DelayOp op = new DelayOp(Duration.ofSeconds(-1));
+        Assert.assertEquals("Execution Delay was not constrained to bounds",
+                Duration.ZERO, op.getExecuteDelay());
     }
 
     /**
      * Test method for {@link Operation}.
      */
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public final void negativeExecutorDelay() throws Throwable {
+    @Test
+    public final void negativeExecutorDelay() {
         DelayOp op = new DelayOp()
                 .executeDelay(Duration.ofSeconds(-1));
+        Assert.assertEquals("Execution Delay was not constrained to bounds",
+                Duration.ZERO, op.getExecuteDelay());
     }
 
     /**
      * Test method for {@link OperationList}.
      */
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public final void negativeRevertDelay() throws Throwable {
+    @Test
+    public final void negativeRevertDelay() {
         DelayOp op = new DelayOp()
                 .revertDelay(Duration.ofSeconds(-1));
+        Assert.assertEquals("Revert Delay was not constrained to bounds",
+                Duration.ZERO, op.getRevertDelay());
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     */
+    @Test
+    public final void extremeConstructorDelay() {
+        DelayOp op = new DelayOp(Duration.ofDays(1));
+        Assert.assertNotEquals("Execution Delay was not constrained to bounds",
+                Duration.ofDays(1), op.getExecuteDelay());
+    }
+
+    /**
+     * Test method for {@link Operation}.
+     */
+    @Test
+    public final void extremeExecutorDelay() {
+        DelayOp op = new DelayOp()
+                .executeDelay(Duration.ofDays(1));
+        Assert.assertNotEquals("Execution Delay was not constrained to bounds",
+                Duration.ofDays(1), op.getExecuteDelay());
+    }
+
+    /**
+     * Test method for {@link OperationList}.
+     */
+    @Test
+    public final void extremeRevertDelay() {
+        DelayOp op = new DelayOp()
+                .revertDelay(Duration.ofDays(1));
+        Assert.assertNotEquals("Revert Delay was not constrained to bounds",
+                Duration.ofDays(1), op.getRevertDelay());
     }
 }

--- a/test-utilities/pom.xml
+++ b/test-utilities/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>com.vmware.test-operations</groupId>
       <artifactId>test-operations-parent</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>test-utilities</artifactId>
 

--- a/test-utilities/src/main/java/com/vmware/operations/utils/FuzzUtils.java
+++ b/test-utilities/src/main/java/com/vmware/operations/utils/FuzzUtils.java
@@ -18,8 +18,8 @@
 
 package com.vmware.operations.utils;
 
+import java.security.SecureRandom;
 import java.util.Calendar;
-import java.util.Random;
 import java.util.TimeZone;
 
 /**
@@ -63,6 +63,8 @@ public class FuzzUtils {
      */
     public static final String UTF16_CHARS = "\u24e1\u2460\u24f6\u2675\u2643\u2464\u277b\u2786\u2791\u0669\u00c5\u00df\u00c7\u00d0\u20ac\u1e1e\u20b2\u021e\u0399\u0134\ua7a2\u00a3\u039c\u00d1\u00d8\u2119\u213a\u13d2\u2c7e\u01ac\u22c3\u2207\u0428\u00d7\u00a5\u017d_-." +
             ")!@#$%^&*(\u00c5\u00df\u00c7\u00d0\u20ac\u1e1e\u20b2\u10ac\u0399\u0134\ua7a2|\u039c\u00d1\u00d8\u2119'\"\u2c7e\u01ac\u22c3\\ {}<>[]";
+
+    private static final SecureRandom RNG = new SecureRandom();
 
     /**
      * Using a prefix, build a random string string with a given length, filled
@@ -142,9 +144,8 @@ public class FuzzUtils {
         }
 
         // Add the minimum number of random digits
-        Random r = new Random();
         for (int i = 0; i < entropy; ++i) {
-            result.append(charset.charAt(r.nextInt(charset.length())));
+            result.append(charset.charAt(RNG.nextInt(charset.length())));
         }
 
         return result.toString();


### PR DESCRIPTION
Update the libraries used to build.  The new version of SpotBugs noticed that we could throw from a constructor of DelayOp.  Instead of preserving the old behavior, it will now bound the delay values and log an error.

The library version was updated to 1.2.0 to reflect that API change.