### PR TITLE
Prepare for a new release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-release-plugin</artifactId>
                         <version>3.0.1</version>
+                        <configuration>
+                          <!-- vmware project settings do not allow direct push -->
+                          <pushChanges>false</pushChanges>
+                        </configuration>
                     </plugin>
 
                     <!--


### PR DESCRIPTION
The 'vmware' github group does not allow push requests, so disable github pushes during the release process.