### PR TITLE
Update to use slf4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
@@ -265,7 +265,7 @@
                     <plugin>
                       <groupId>org.jacoco</groupId>
                       <artifactId>jacoco-maven-plugin</artifactId>
-                      <version>0.8.8</version>
+                      <version>0.8.11</version>
                       <executions>
                         <execution>
                           <goals>

--- a/test-operations/pom.xml
+++ b/test-operations/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test-operations/src/test/java/com/vmware/operations/OperationTest.java
+++ b/test-operations/src/test/java/com/vmware/operations/OperationTest.java
@@ -37,13 +37,13 @@ public class OperationTest {
 
     @Test
     public void utilityClassIsWellFormed() throws Exception {
-        Constructor[] ctors = Operations.class.getDeclaredConstructors();
+        Constructor<?>[] ctors = Operations.class.getDeclaredConstructors();
         Assert.assertEquals("Utility class should only have one constructor",
                 1, ctors.length);
-        Constructor ctor = ctors[0];
+        Constructor<?> ctor = ctors[0];
         Assert.assertFalse("Utility class constructor should be inaccessible",
-                ctor.isAccessible());
-        ctor.setAccessible(true); // obviously we'd never do this in production
+                ctor.canAccess(null));
+        ctor.setAccessible(true); // obviously we'd never do this outside of tests
         Assert.assertEquals("You'd expect the construct to return the expected type",
                 Operations.class, ctor.newInstance().getClass());
     }

--- a/test-utilities/pom.xml
+++ b/test-utilities/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The latest dependency update didn't completely switch all of the dependencies correctly for the SLF4J v2 update.

Also, clean up some Java complier warnings about deprecated language features.